### PR TITLE
Fix getLoadEavAttributesCriteria function

### DIFF
--- a/EEavBehavior.php
+++ b/EEavBehavior.php
@@ -493,7 +493,7 @@ class EEavBehavior extends CActiveRecordBehavior {
      */
     protected function getLoadEavAttributesCriteria($attributes = array()) {
         $criteria = new CDbCriteria;
-        $criteria->addCondition("{$this->entityField} = {$this->getModelId()}");
+        $criteria->compare($this->entityField, $this->getModelId());
         if (!empty($attributes)) {
             $criteria->addInCondition($this->attributeField, $attributes);
         }


### PR DESCRIPTION
If ActiveRecord, which use EEAVBehavior, has a string as PK, then getLoadEavAttributesCriteria function return broken SQL query, with non-quoted value.

Here is a line:
https://github.com/yiiext/eav-behavior/blob/master/EEavBehavior.php#L496
